### PR TITLE
Fix a bug with lazy loading

### DIFF
--- a/imaspy/backends/imas_core/db_entry_helpers.py
+++ b/imaspy/backends/imas_core/db_entry_helpers.py
@@ -77,10 +77,14 @@ def get_children(
                 getattr(structure, name)._IDSPrimitive__value = data
 
 
-def _get_child(child: IDSBase, ctx: LazyALContext):
+def _get_child(child: IDSBase, ctx: Optional[LazyALContext]):
     """Get a single child when required (lazy loading)."""
     # NOTE: changes in this method must be propagated to _get_children and vice versa
     #   Performance: this method is specialized for the lazy get
+
+    # ctx can be None when the parent structure does not exist in the on-disk DD version
+    if ctx is None:
+        return  # There is no data to be loaded
 
     time_mode = ctx.time_mode
     if time_mode == IDS_TIME_MODE_INDEPENDENT and child.metadata.type.is_dynamic:

--- a/imaspy/test/test_lazy_loading.py
+++ b/imaspy/test/test_lazy_loading.py
@@ -165,6 +165,22 @@ def test_lazy_load_with_new_aos(requires_imas):
     dbentry.close()
 
 
+def test_lazy_load_with_new_structure(requires_imas):
+    dbentry = DBEntry(MEMORY_BACKEND, "ITER", 1, 1, dd_version="3.30.0")
+    dbentry.create()
+
+    eq = dbentry.factory.equilibrium()
+    eq.ids_properties.homogeneous_time = IDS_TIME_MODE_HOMOGENEOUS
+    eq.time = [0.0]
+    eq.time_slice.resize(1)
+    dbentry.put(eq)
+
+    entry2 = DBEntry(MEMORY_BACKEND, "ITER", 1, 1, data_version="3", dd_version="4.0.0")
+    entry2.open()
+    lazy_eq = entry2.get("equilibrium", lazy=True)
+    assert not lazy_eq.time_slice[0].boundary.dr_dz_zero_point.r.has_value
+
+
 def test_lazy_load_multiple_ids(backend, worker_id, tmp_path):
     if backend == ASCII_BACKEND:
         pytest.skip("Lazy loading is not supported by the ASCII backend.")


### PR DESCRIPTION
Bug: IMASPy runs into an attribute error when lazy loading a child quantity that was added in a newer DD version than stored on disk.

Example:
1. Equilibrium IDS stored in DD 3.33.0
2. Lazy loading IDS with DD 4.0.0
3. Try to access `eq.time_slice[0].boundary.dr_dz_zero_point.r` resulted in an AttributeError

Root cause: IMASPy did not handle correctly that the `dr_dz_zero_point` was added between 3.33.0 and 4.0.0.

This commit fixes the bug.