### PR TITLE
Implement implicit conversion, lazy loading and some performance improvements for netCDF backend

### DIFF
--- a/docs/source/netcdf.rst
+++ b/docs/source/netcdf.rst
@@ -11,7 +11,7 @@ IMAS netCDF files
 
 IMAS-Python supports reading IDSs from and writing IDSs to IMAS netCDF files. This
 feature is currently in alpha status, and its functionality may change in
-upcoming minor releases of IMAS-Python.
+upcoming (minor) releases of IMAS-Python.
 
 A detailed description of the IMAS netCDF format and conventions can be found on
 the :ref:`IMAS conventions for the netCDF data format` page.
@@ -40,6 +40,34 @@ will be used for :py:meth:`~imas.db_entry.DBEntry.get` and
         cp2 = netcdf_entry.get("core_profiles")
 
     imas.util.print_tree(cp2)
+
+
+Implemented features of a netCDF ``DBEntry``
+--------------------------------------------
+
+A netCDF ``DBEntry`` doesn't implement all features that are supported by
+``imas_core``. The following table provides an overview of the implemented
+features that are supported by DBEntries using ``imas_core`` respectively
+``netCDF``:
+
+.. list-table::
+    :header-rows: 1
+    
+    * - Feature
+      - ``imas_core``
+      - ``netCDF``
+    * - :ref:`Lazy loading`
+      - Yes
+      - Yes
+    * - :ref:`Automatic conversion between DD versions <Conversion of IDSs between DD versions>`
+      - When reading and writing
+      - When reading
+    * - ``get_slice`` / ``put_slice``
+      - Yes
+      - Not implemented
+    * - ``get_sample``
+      - Yes (requires ``imas_core >= 5.4.0``)
+      - Not implemented
 
 
 Using IMAS netCDF files with 3rd-party tools

--- a/imas/backends/imas_core/al_context.py
+++ b/imas/backends/imas_core/al_context.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple
 
 import numpy
 
+import imas
 from imas.backends.imas_core.imas_interface import ll_interface
 from imas.exception import LowlevelError
 from imas.ids_defs import (
@@ -279,6 +280,9 @@ class LazyALContext:
         """Time mode used by the IDS being lazy loaded."""
         self.context = None
         """Potential weak reference to opened context."""
+
+    def get_child(self, child):
+        imas.backends.imas_core.db_entry_helpers._get_child(child, self)
 
     def get_context(self) -> ALContext:
         """Create and yield the actual ALContext."""

--- a/imas/backends/imas_core/db_entry_helpers.py
+++ b/imas/backends/imas_core/db_entry_helpers.py
@@ -22,7 +22,7 @@ def get_children(
     structure: IDSStructure,
     ctx: ALContext,
     time_mode: int,
-    nbc_map: Optional[NBCPathMap],
+    nbc_map: Optional["NBCPathMap"],
 ) -> None:
     """Recursively get all children of an IDSStructure."""
     # NOTE: changes in this method must be propagated to _get_child and vice versa
@@ -77,14 +77,10 @@ def get_children(
                 getattr(structure, name)._IDSPrimitive__value = data
 
 
-def _get_child(child: IDSBase, ctx: Optional[LazyALContext]):
+def _get_child(child: IDSBase, ctx: LazyALContext):
     """Get a single child when required (lazy loading)."""
     # NOTE: changes in this method must be propagated to _get_children and vice versa
     #   Performance: this method is specialized for the lazy get
-
-    # ctx can be None when the parent structure does not exist in the on-disk DD version
-    if ctx is None:
-        return  # There is no data to be loaded
 
     time_mode = ctx.time_mode
     if time_mode == IDS_TIME_MODE_INDEPENDENT and child.metadata.type.is_dynamic:
@@ -148,7 +144,7 @@ def put_children(
     ctx: ALContext,
     time_mode: int,
     is_slice: bool,
-    nbc_map: Optional[NBCPathMap],
+    nbc_map: Optional["NBCPathMap"],
     verify_maxoccur: bool,
 ) -> None:
     """Recursively put all children of an IDSStructure"""

--- a/imas/backends/imas_core/imas_interface.py
+++ b/imas/backends/imas_core/imas_interface.py
@@ -32,7 +32,7 @@ except ImportError as exc:
     imasdef = None
     lowlevel = None
     logger.critical(
-        "Could not import 'al_core': %s. Some functionality is not available.",
+        "Could not import 'imas_core': %s. Some functionality is not available.",
         exc,
     )
 

--- a/imas/backends/netcdf/db_entry_nc.py
+++ b/imas/backends/netcdf/db_entry_nc.py
@@ -108,10 +108,6 @@ class NCDBEntryImpl(DBEntryImpl):
             else:
                 func = "get_sample"
             raise NotImplementedError(f"`{func}` is not available for netCDF files.")
-        if lazy:
-            raise NotImplementedError(
-                "Lazy loading is not implemented for netCDF files."
-            )
 
         # Check if the IDS/occurrence exists, and obtain the group it is stored in
         try:
@@ -123,7 +119,7 @@ class NCDBEntryImpl(DBEntryImpl):
 
         # Load data into the destination IDS
         if self._ds_factory.dd_version == destination._dd_version:
-            NC2IDS(group, destination, destination.metadata, None).run()
+            NC2IDS(group, destination, destination.metadata, None).run(lazy)
         else:
             # Construct relevant NBCPathMap, the one we get from DBEntry has the reverse
             # mapping from what we need. The imas_core logic does the mapping from
@@ -135,7 +131,7 @@ class NCDBEntryImpl(DBEntryImpl):
             nbc_map = ddmap.old_to_new if source_is_older else ddmap.new_to_old
             NC2IDS(
                 group, destination, self._ds_factory.new(ids_name).metadata, nbc_map
-            ).run()
+            ).run(lazy)
 
         return destination
 

--- a/imas/backends/netcdf/db_entry_nc.py
+++ b/imas/backends/netcdf/db_entry_nc.py
@@ -11,7 +11,7 @@ from imas.backends.db_entry_impl import (
 from imas.backends.netcdf.ids2nc import IDS2NC
 from imas.backends.netcdf.nc2ids import NC2IDS
 from imas.exception import DataEntryException, InvalidNetCDFEntry
-from imas.ids_convert import NBCPathMap, convert_ids
+from imas.ids_convert import NBCPathMap, dd_version_map_from_factories
 from imas.ids_factory import IDSFactory
 from imas.ids_toplevel import IDSToplevel
 
@@ -123,14 +123,19 @@ class NCDBEntryImpl(DBEntryImpl):
 
         # Load data into the destination IDS
         if self._ds_factory.dd_version == destination._dd_version:
-            NC2IDS(group, destination).run()
+            NC2IDS(group, destination, destination.metadata, None).run()
         else:
-            # FIXME: implement automatic conversion using nbc_map
-            #   As a work-around: do an explicit conversion, but automatic conversion
-            #   will also be needed to implement lazy loading.
-            ids = self._ds_factory.new(ids_name)
-            NC2IDS(group, ids).run()
-            convert_ids(ids, None, target=destination)
+            # Construct relevant NBCPathMap, the one we get from DBEntry has the reverse
+            # mapping from what we need. The imas_core logic does the mapping from
+            # in-memory to on-disk, while we take what is on-disk and map it to
+            # in-memory.
+            ddmap, source_is_older = dd_version_map_from_factories(
+                ids_name, self._ds_factory, self._factory
+            )
+            nbc_map = ddmap.old_to_new if source_is_older else ddmap.new_to_old
+            NC2IDS(
+                group, destination, self._ds_factory.new(ids_name).metadata, nbc_map
+            ).run()
 
         return destination
 

--- a/imas/backends/netcdf/nc2ids.py
+++ b/imas/backends/netcdf/nc2ids.py
@@ -184,20 +184,25 @@ class NC2IDS:
                     for index, node in tree_iter(self.ids, target_metadata):
                         shape = shapes[index]
                         if shape.all():
-                            node.value = data[index + tuple(map(slice, shapes[index]))]
+                            # NOTE: bypassing IDSPrimitive.value.setter logic
+                            node._IDSPrimitive__value = data[
+                                index + tuple(map(slice, shape))
+                            ]
                 else:
                     for index, node in tree_iter(self.ids, target_metadata):
                         value = data[index]
                         if value != getattr(var, "_FillValue", None):
-                            node.value = data[index]
+                            # NOTE: bypassing IDSPrimitive.value.setter logic
+                            node._IDSPrimitive__value = value
 
             elif metadata.path_string not in self.ncmeta.aos:
                 # Shortcut for assigning untensorized data
-                self.ids[target_metadata.path] = data
+                self.ids[target_metadata.path]._IDSPrimitive__value = data
 
             else:
                 for index, node in tree_iter(self.ids, target_metadata):
-                    node.value = data[index]
+                    # NOTE: bypassing IDSPrimitive.value.setter logic
+                    node._IDSPrimitive__value = data[index]
 
     def validate_variables(self) -> None:
         """Validate that all variables in the netCDF Group exist and match the DD."""

--- a/imas/backends/netcdf/nc2ids.py
+++ b/imas/backends/netcdf/nc2ids.py
@@ -206,7 +206,9 @@ class NC2IDS:
 
             elif metadata.path_string not in self.ncmeta.aos:
                 # Shortcut for assigning untensorized data
-                self.ids[target_metadata.path]._IDSPrimitive__value = data
+                # Note: var[()] can return 0D numpy arrays. Instead of handling this
+                # here, we'll let IDSPrimitive.value.setter take care of it:
+                self.ids[target_metadata.path].value = data
 
             else:
                 for index, node in tree_iter(self.ids, target_metadata):

--- a/imas/backends/netcdf/nc_validate.py
+++ b/imas/backends/netcdf/nc_validate.py
@@ -47,8 +47,9 @@ def validate_netcdf_file(filename: str) -> None:
         for ids_name in ids_names:
             for occurrence in entry.list_all_occurrences(ids_name):
                 group = dataset[f"{ids_name}/{occurrence}"]
+                ids = factory.new(ids_name)
                 try:
-                    NC2IDS(group, factory.new(ids_name)).validate_variables()
+                    NC2IDS(group, ids, ids.metadata, None).validate_variables()
                 except InvalidNetCDFEntry as exc:
                     occ = f":{occurrence}" if occurrence else ""
                     raise InvalidNetCDFEntry(f"Invalid IDS {ids_name}{occ}: {exc}")

--- a/imas/test/test_nc_validation.py
+++ b/imas/test/test_nc_validation.py
@@ -32,7 +32,7 @@ def memfile_with_ids(memfile, factory):
     IDS2NC(ids, memfile).run()
     # This one is valid:
     ids = factory.core_profiles()
-    NC2IDS(memfile, ids, ids.metadata, None).run()
+    NC2IDS(memfile, ids, ids.metadata, None).run(lazy=False)
     return memfile
 
 
@@ -65,18 +65,18 @@ def test_invalid_units(memfile_with_ids, factory):
     memfile_with_ids["time"].units = "hours"
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_invalid_documentation(memfile_with_ids, factory, caplog):
     ids = factory.core_profiles()
     with caplog.at_level("WARNING"):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
     assert not caplog.records
     # Invalid docstring logs a warning
     memfile_with_ids["time"].documentation = "https://en.wikipedia.org/wiki/Time"
     with caplog.at_level("WARNING"):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
     assert len(caplog.records) == 1
 
 
@@ -84,42 +84,42 @@ def test_invalid_dimension_name(memfile_with_ids, factory):
     memfile_with_ids.renameDimension("time", "T")
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_invalid_coordinates(memfile_with_ids, factory):
     memfile_with_ids["profiles_1d.grid.rho_tor_norm"].coordinates = "xyz"
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_invalid_ancillary_variables(memfile_with_ids, factory):
     memfile_with_ids["time"].ancillary_variables = "xyz"
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_extra_attributes(memfile_with_ids, factory):
     memfile_with_ids["time"].new_attribute = [1, 2, 3]
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_shape_array_without_data(memfile_with_ids, factory):
     memfile_with_ids.createVariable("profiles_1d.t_i_average:shape", int, ())
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_shape_array_without_sparse_data(memfile_with_ids, factory):
     memfile_with_ids.createVariable("profiles_1d.grid.rho_tor_norm:shape", int, ())
     ids = factory.core_profiles()
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run()
+        NC2IDS(memfile_with_ids, ids, ids.metadata, None).run(lazy=False)
 
 
 def test_shape_array_with_invalid_dimensions(memfile_with_ids, factory):
@@ -137,7 +137,7 @@ def test_shape_array_with_invalid_dimensions(memfile_with_ids, factory):
         ("time", "profiles_1d.grid.rho_tor_norm:i"),
     )
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, cp, cp.metadata, None).run()
+        NC2IDS(memfile_with_ids, cp, cp.metadata, None).run(lazy=False)
 
 
 def test_shape_array_with_invalid_dtype(memfile_with_ids, factory):
@@ -153,7 +153,7 @@ def test_shape_array_with_invalid_dtype(memfile_with_ids, factory):
         "profiles_1d.t_i_average:shape", float, ("time", "1D")
     )
     with pytest.raises(InvalidNetCDFEntry):
-        NC2IDS(memfile_with_ids, cp, cp.metadata, None).run()
+        NC2IDS(memfile_with_ids, cp, cp.metadata, None).run(lazy=False)
 
 
 def test_validate_nc(tmpdir):


### PR DESCRIPTION
This Pull Request implements the following improvements for the netCDF backend:

1. Automatic DD version conversion on `get()`. This has the same limitations as the automatic conversion using `imas_core`, as outlined in [the documentation](https://imas-python.readthedocs.io/en/latest/multi-dd.html#supported-conversions).
**N.B.** automatic conversion during `put()` is still not supported, since this is rarely needed and easily worked around.
2. Lazy loading: only load data from the netCDF file when it is accessed by users.
3. Minor performance improvement: skip the `IDSPrimitive.value.setter` logic when loading data from a netCDF file (the same optimization was already in place for reading from an `imas_core` backend).