### PR TITLE
Fix missing COCOS sign conversion

### DIFF
--- a/imas/ids_convert.py
+++ b/imas/ids_convert.py
@@ -1,7 +1,6 @@
 # This file is part of IMAS-Python.
 # You should have received the IMAS-Python LICENSE file with this project.
-"""Functionality for converting IDSToplevels between DD versions.
-"""
+"""Functionality for converting IDSToplevels between DD versions."""
 
 import copy
 import datetime
@@ -334,12 +333,13 @@ class DDVersionMap:
         # Additional conversion rules for DDv3 to DDv4
         if self.version_old.major == 3 and new_version and new_version.major == 4:
             # Postprocessing for COCOS definition change:
-            xpath_query = ".//field[@cocos_label_transformation='psi_like']"
-            for old_item in old.iterfind(xpath_query):
-                old_path = old_item.get("path")
-                new_path = self.old_to_new.path.get(old_path, old_path)
-                self.new_to_old.post_process[new_path] = _cocos_change
-                self.old_to_new.post_process[old_path] = _cocos_change
+            for psi_like in ["psi_like", "dodpsi_like"]:
+                xpath_query = f".//field[@cocos_label_transformation='{psi_like}']"
+                for old_item in old.iterfind(xpath_query):
+                    old_path = old_item.get("path")
+                    new_path = self.old_to_new.path.get(old_path, old_path)
+                    self.new_to_old.post_process[new_path] = _cocos_change
+                    self.old_to_new.post_process[old_path] = _cocos_change
             # Definition change for pf_active circuit/connections
             if self.ids_name == "pf_active":
                 path = "circuit/connections"

--- a/imas/test/test_ids_convert.py
+++ b/imas/test/test_ids_convert.py
@@ -368,6 +368,26 @@ def test_3to4_cocos_change(dd4factory):
     cp3 = convert_ids(cp4, "3.39.0")
     compare_children(cp, cp3)
 
+    eq = IDSFactory("3.39.0").equilibrium()
+    eq.ids_properties.homogeneous_time = IDS_TIME_MODE_HOMOGENEOUS
+    eq.time = [1.0]
+    eq.time_slice.resize(1)
+    eq.time_slice[0].profiles_1d.psi = numpy.linspace(0, 1, 11)
+    eq.time_slice[0].profiles_1d.dpressure_dpsi = numpy.linspace(1, 2, 11)
+
+    eq4 = convert_ids(eq, None, factory=dd4factory)
+    assert numpy.array_equal(
+        eq4.time_slice[0].profiles_1d.psi,
+        -eq.time_slice[0].profiles_1d.psi,
+    )
+    assert numpy.array_equal(
+        eq4.time_slice[0].profiles_1d.dpressure_dpsi,
+        -eq.time_slice[0].profiles_1d.dpressure_dpsi,
+    )
+
+    eq3 = convert_ids(eq4, "3.39.0")
+    compare_children(eq, eq3)
+
 
 def test_3to4_circuit_connections(dd4factory, caplog):
     pfa = IDSFactory("3.39.0").pf_active()


### PR DESCRIPTION
Also apply COCOS 11/17 sign conversion to `dodpsi_like` when converting between DD 3 and 4.

Fixes #31.