### PR TITLE
Remove numpy<2 restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # FIXME: numpy 2.0 compatibility
-    "numpy>=1.15.4,<2",
+    "numpy>=1.15.4",
     "rich",
     "scipy",
     "click",


### PR DESCRIPTION
Pytest runs successfully with numpy 2.x, so we should be able to remove this restriction.