### PR TITLE
Use datapath with UDA when fetching IDS properties

### DIFF
--- a/imas/backends/imas_core/al_context.py
+++ b/imas/backends/imas_core/al_context.py
@@ -1,7 +1,6 @@
 # This file is part of IMAS-Python.
 # You should have received the IMAS-Python LICENSE file with this project.
-"""Object-oriented interface to the IMAS lowlevel.
-"""
+"""Object-oriented interface to the IMAS lowlevel."""
 
 import logging
 import weakref
@@ -61,17 +60,21 @@ class ALContext:
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         ll_interface.end_action(self.ctx)
 
-    def global_action(self, path: str, rwmode: int) -> "ALContext":
+    def global_action(self, path: str, rwmode: int, datapath: str = "") -> "ALContext":
         """Begin a new global action for use in a ``with`` context.
 
         Args:
             path: access layer path for this global action: ``<idsname>[/<occurrence>]``
             rwmode: read-only or read-write operation mode: ``READ_OP``/``WRITE_OP``
+            datapath: used by UDA backend to fetch only part of the data.
 
         Returns:
             The created context.
         """
-        status, ctx = ll_interface.begin_global_action(self.ctx, path, rwmode)
+        args = [self.ctx, path, rwmode]
+        if datapath:  # AL4 compatibility: datapath arg was added in AL5
+            args.append(datapath)
+        status, ctx = ll_interface.begin_global_action(*args)
         if status != 0:
             raise LowlevelError("global_action", status)
         return ALContext(ctx)

--- a/imas/backends/imas_core/db_entry_al.py
+++ b/imas/backends/imas_core/db_entry_al.py
@@ -257,7 +257,8 @@ class ALDBEntryImpl(DBEntryImpl):
         if occurrence != 0:
             ll_path += f"/{occurrence}"
 
-        with self._db_ctx.global_action(ll_path, READ_OP) as read_ctx:
+        datapath = "ids_properties" if self.backend == "uda" else ""
+        with self._db_ctx.global_action(ll_path, READ_OP, datapath) as read_ctx:
             time_mode_path = "ids_properties/homogeneous_time"
             time_mode = read_ctx.read_data(time_mode_path, "", INTEGER_DATA, 0)
             # This is already checked by read_dd_version, but ensure:
@@ -314,7 +315,8 @@ class ALDBEntryImpl(DBEntryImpl):
         if occurrence != 0:
             ll_path += f"/{occurrence}"
 
-        with self._db_ctx.global_action(ll_path, READ_OP) as read_ctx:
+        datapath = "ids_properties" if self.backend == "uda" else ""
+        with self._db_ctx.global_action(ll_path, READ_OP, datapath) as read_ctx:
             time_mode_path = "ids_properties/homogeneous_time"
             time_mode = read_ctx.read_data(time_mode_path, "", INTEGER_DATA, 0)
             dd_version_path = "ids_properties/version_put/data_dictionary"


### PR DESCRIPTION
We request `ids_properties/homogeneous_time` and
`ids_properties/version_put/data_dictionary` in two separate calls to the backend before actually getting all data. This is fine for local backends, but UDA would fetch the data three times:

1. When determining the DD version and if the IDS exists
2. When determining whether the IDS uses homogeneous time
3. When actually reading the data

This commit adds a `datapath="ids_properties"` to the first two cases. This results in UDA only fetching the IDS properties in points 1 and 2. The full IDS is now requested once by UDA, in point 3.