### PR TITLE
Revert "Update backend selection logic"

### DIFF
--- a/imas/db_entry.py
+++ b/imas/db_entry.py
@@ -1,6 +1,7 @@
 # This file is part of IMAS-Python.
 # You should have received the IMAS-Python LICENSE file with this project.
-"""Logic for interacting with IMAS Data Entries."""
+"""Logic for interacting with IMAS Data Entries.
+"""
 
 import logging
 import os
@@ -188,10 +189,10 @@ class DBEntry:
     @staticmethod
     def _select_implementation(uri: Optional[str]) -> Type[DBEntryImpl]:
         """Select which DBEntry implementation to use based on the URI."""
-        if not uri or uri.startswith("imas:"):
-            from imas.backends.imas_core.db_entry_al import ALDBEntryImpl as impl
-        else:  # Assume it's a netCDF file or NCZarr URI
+        if uri and uri.endswith(".nc") and not uri.startswith("imas:"):
             from imas.backends.netcdf.db_entry_nc import NCDBEntryImpl as impl
+        else:
+            from imas.backends.imas_core.db_entry_al import ALDBEntryImpl as impl
         return impl
 
     def __enter__(self):


### PR DESCRIPTION
This reverts commit 33e6b7e28516ebd9b276ad98e7e8a76e9f54a145.

Updated backend selection logic can lead to unexpected situations when making a typo in the URI, for example:

```python
with imas.DBEntry("imas;hdf5?path=xyz", "w") as entry:
    entry.put(ids)
```

Will now happily create a netCDF file `imas;hdf5?path=xyz` with the `develop` branch. Changing this logic back will raise an exception by `imas_core`.