### PR TITLE
Modify lazy loading test to generate random data without complex numbers.

### DIFF
--- a/imas/test/test_lazy_loading.py
+++ b/imas/test/test_lazy_loading.py
@@ -78,7 +78,7 @@ def test_lazy_loading_distributions_random_netcdf(tmp_path):
 
 def run_lazy_loading_distributions_random(dbentry):
     ids = IDSFactory().new("distributions")
-    fill_consistent(ids)
+    fill_consistent(ids, skip_complex=True)
     dbentry.put(ids)
 
     def iterate(structure):


### PR DESCRIPTION
This is a proposed solution to allow for netCDF4<1.7.0 support for the tests. If there is a better way to handle this please let me know.