### PR TITLE
Ensure that 0D numpy arrays are unpacked when filling lazy loaded IDS from netCDF files

### DIFF
--- a/imas/backends/netcdf/nc2ids.py
+++ b/imas/backends/netcdf/nc2ids.py
@@ -366,9 +366,12 @@ class LazyContext:
 
             if value is not None:
                 if isinstance(value, np.ndarray):
-                    # Convert the numpy array to a read-only view
-                    value = value.view()
-                    value.flags.writeable = False
+                    if value.ndim == 0:  # Unpack 0D numpy arrays:
+                        value = value.item()
+                    else:
+                        # Convert the numpy array to a read-only view
+                        value = value.view()
+                        value.flags.writeable = False
                 # NOTE: bypassing IDSPrimitive.value.setter logic
                 child._IDSPrimitive__value = value
 


### PR DESCRIPTION

```python
>>> entry = imas.DBEntry("ascii.nc", "r")
>>> eq = entry.get("equilibrium", autoconvert=False, lazy=True)
>>> # Previous behaviour:
>>> eq.ids_properties.homogeneous_time
<IDSInt0D (IDS:equilibrium, ids_properties/homogeneous_time, INT_0D)>
ndarray(array(1, dtype=int32))
>>> # New behaviour, matches with non-lazy IDS:
>>> eq.ids_properties.homogeneous_time
<IDSInt0D (IDS:equilibrium, ids_properties/homogeneous_time, INT_0D)>
int(1)
```