### PR TITLE
Update python versions used in github actions

### DIFF
--- a/.github/workflows/test_with_pytest.yml
+++ b/.github/workflows/test_with_pytest.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]  # Test on multiple Python versions
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions
     
     steps:
       - name: Checkout repository
@@ -20,8 +20,6 @@ jobs:
 
         uses: actions/setup-python@v4
         with:
-          # until saxonche is available in 3.13
-          # https://saxonica.plan.io/issues/6561
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/test_with_pytest.yml
+++ b/.github/workflows/test_with_pytest.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/test_with_pytest.yml
+++ b/.github/workflows/test_with_pytest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions

--- a/.github/workflows/test_with_pytest.yml
+++ b/.github/workflows/test_with_pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]  # Test on multiple Python versions
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Remove Python 3.8 (which is already end-of-life for ~10 months) and add Python 3.13.
- Update OS to `ubuntu-latest` instead of a fixed version