### PR TITLE
Add warning when a user implicitly converts an IDS between major versions on put()

### DIFF
--- a/docs/source/multi-dd.rst
+++ b/docs/source/multi-dd.rst
@@ -23,7 +23,7 @@ example:
     factory_3_32_0 = imas.IDSFactory("3.32.0")  # Use DD version 3.32.0
 
     # Will write IDSs to the backend in DD version 3.32.0
-    dbentry = imas.DBEntry(imas.ids_defs.HDF5_BACKEND, "TEST", 10, 2, version="3.32.0")
+    dbentry = imas.DBEntry("imas:hdf5?path=dd3.32.0-output/", "w", dd_version="3.32.0")
     dbentry.create()
 
 .. seealso:: :ref:`multi-dd training`

--- a/imas/backends/imas_core/db_entry_al.py
+++ b/imas/backends/imas_core/db_entry_al.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from packaging.version import Version
 
+import imas
 from imas.backends.db_entry_impl import GetSampleParameters, GetSliceParameters
 from imas.db_entry import DBEntryImpl
 from imas.exception import DataEntryException, LowlevelError
@@ -280,6 +281,16 @@ class ALDBEntryImpl(DBEntryImpl):
         # Create a version conversion map, if needed
         nbc_map = None
         if ids._version != self._ids_factory._version:
+            if ids._version.split(".")[0] != self._ids_factory._version.split(".")[0]:
+                logger.warning(
+                    "Provided IDS uses DD %s which has a different major version than "
+                    "the Data Entry (%s). IMAS-Python will convert the data "
+                    "automatically, but this does not cover all changes. "
+                    "See %s/multi-dd.html#conversion-of-idss-between-dd-versions",
+                    ids._version,
+                    self._ids_factory._version,
+                    imas.PUBLISHED_DOCUMENTATION_ROOT,
+                )
             ddmap, source_is_older = dd_version_map_from_factories(
                 ids_name, ids._parent, self._ids_factory
             )


### PR DESCRIPTION
And fix an example in the multi-DD documentation.

---

@olivhoenen implicit data conversion on put() is perhaps too confusing to users. We could also choose to remove the feature altogether and raise an error when trying to `put` or `put_slice` an IDS with a different DD version than the DBEntry.
See also the discussion with @DavidPCoster in the IMASusers Slack.