### PR TITLE
Defer loading the default DD definitions

### DIFF
--- a/imas/backends/db_entry_impl.py
+++ b/imas/backends/db_entry_impl.py
@@ -78,7 +78,7 @@ class DBEntryImpl(ABC):
         destination: IDSToplevel,
         lazy: bool,
         nbc_map: Optional[NBCPathMap],
-    ) -> None:
+    ) -> IDSToplevel:
         """Implement DBEntry.get/get_slice/get_sample. Load data from the data source.
 
         Args:

--- a/imas/db_entry.py
+++ b/imas/db_entry.py
@@ -160,7 +160,7 @@ class DBEntry:
                 legacy = True
             except TypeError as exc2:
                 raise TypeError(
-                    f"Incorrect arguments to {__class__.__name__}.__init__(): "
+                    "Incorrect arguments to DBEntry.__init__(): "
                     f"{exc1.args[0]}, {exc2.args[0]}"
                 ) from None
 
@@ -561,7 +561,7 @@ class DBEntry:
             raise RuntimeError("Database entry is not open.")
         if lazy and destination:
             raise ValueError("Cannot supply a destination IDS when lazy loading.")
-        if not self._ids_factory.exists(ids_name):
+        if autoconvert and not self._ids_factory.exists(ids_name):
             raise IDSNameError(ids_name, self._ids_factory)
 
         # Note: this will raise an exception when the ids/occurrence is not filled:
@@ -577,7 +577,7 @@ class DBEntry:
                 ids_name,
                 occurrence,
             )
-        elif dd_version != self.dd_version and dd_version not in dd_xml_versions():
+        elif dd_version not in dd_xml_versions() and dd_version != self.dd_version:
             # We don't know the DD version that this IDS was written with
             if ignore_unknown_dd_version:
                 # User chooses to ignore this problem, load as if it was stored with

--- a/imas/ids_factory.py
+++ b/imas/ids_factory.py
@@ -41,6 +41,17 @@ class IDSFactory:
             version: DD version string, e.g. "3.38.1".
             xml_path: XML file containing data dictionary definition.
         """
+        if version is None and xml_path is None:
+            # Defer loading the DD definitions until we really need them
+            self.__deferred_init = True
+        else:
+            # If a specific version or xml_path is requested, we still load immediately
+            # so any exceptions are raise when creating the IDSfactory
+            self.__do_init(version, xml_path)
+            self.__deferred_init = False
+
+    def __do_init(self, version: str | None, xml_path: str | pathlib.Path | None):
+        """Actual initalization logic"""
         self._xml_path = xml_path
         self._etree = dd_zip.dd_etree(version, xml_path)
         self._ids_elements = {
@@ -71,10 +82,16 @@ class IDSFactory:
         return sorted(set(object.__dir__(self)).union(self._ids_elements))
 
     def __getattr__(self, name: str) -> Any:
+        # Actually initialize when we deferred it before
+        if self.__deferred_init:
+            self.__do_init(None, None)
+            self.__deferred_init = False
+            return getattr(self, name)
+        # Check if the name matches any IDS and return a 'constructor' for it
         if name in self._ids_elements:
             # Note: returning a partial to mimic AL HLI, e.g. factory.core_profiles()
             return partial(IDSToplevel, self, self._ids_elements[name])
-        raise AttributeError(f"{type(self)!r} object has no attribute {name!r}")
+        raise AttributeError(f"'IDSFactory' has no attribute {name!r}")
 
     def __iter__(self) -> Iterator[str]:
         """Iterate over the IDS names defined by the loaded Data Dictionary"""

--- a/imas/ids_factory.py
+++ b/imas/ids_factory.py
@@ -51,7 +51,7 @@ class IDSFactory:
             self.__deferred_init = False
 
     def __do_init(self, version: str | None, xml_path: str | pathlib.Path | None):
-        """Actual initalization logic"""
+        """Actual initialization logic"""
         self._xml_path = xml_path
         self._etree = dd_zip.dd_etree(version, xml_path)
         self._ids_elements = {


### PR DESCRIPTION
When constructing a DBEntry, a corresponding IDSFactory is created as well. Previously, constructing an IDSFactory would eagerly load the associated Data Dictionary XML files.

In some use cases (e.g. `imas print` or visualization libraries like IMAS-Paraview). A default DBEntry is constructed, but all IDSs are read with `autoconvert=False`. If these IDSs are in an older version of the Data Dictionary, we would previously unnecessarily parse two DD definitions. This was visible to users in the logging output, for example with `imas print`:

```
$ imas print imas:ascii?path=imas/assets core_profiles
[...] INFO     Parsing data dictionary version 4.1.0
[...] INFO     Parsing data dictionary version 3.39.0
[...]
```

This commit defers loading the default Data Dictionary definitions until they are really needed. In the `imas print` scenario above, this will skip loading the DD 4.1.0 definitions: saving a bit of time and potential confusion for users.

The most visible side effect of this change is in interactive Python sessions:

```python
>>> import imas
>>> factory = imas.IDSFactory()
>>> cp = factory.core_profiles()
[...] INFO     Parsing data dictionary version 4.1.0
```

Before this change, the INFO log message would appear immediately after constructing the `IDSFactory`. Now, the XML file is only parsed when we need it for constructing the `core_profiles` IDS.

N.B. Also fix a couple of type warnings from `ty` in touched files.