### PR TITLE
Fix training assets 

### DIFF
--- a/imas/assets/ITER_134173_106_equilibrium.ids
+++ b/imas/assets/ITER_134173_106_equilibrium.ids
@@ -26,8 +26,6 @@ equilibrium/vacuum_toroidal_field/b0
 	dim: 1
 	size: 3 
 -5.2999999999999998e+00 -5.2999999999999998e+00 -5.2999999999999998e+00 
-equilibrium/grids_ggd
-	size: 1
 equilibrium/time_slice
 	size: 3
 equilibrium/time_slice[0]/boundary/outline/r

--- a/imas/test/test_convert_core_edge_plasma.py
+++ b/imas/test/test_convert_core_edge_plasma.py
@@ -12,7 +12,7 @@ def assert_equal(core_edge, plasma):
 
 
 def test_convert_training_core_profiles():
-    with imas.training.get_training_db_entry() as entry:
+    with imas.training.get_training_db_entry(convert=True) as entry:
         cp = entry.get("core_profiles")
 
     pp = imas.convert_to_plasma_profiles(cp)

--- a/imas/training.py
+++ b/imas/training.py
@@ -2,8 +2,6 @@
 # You should have received the IMAS-Python LICENSE file with this project.
 """Functions that are useful for the IMAS-Python training courses."""
 
-from unittest.mock import patch
-
 try:
     from importlib.resources import files
 except ImportError:  # Python 3.8 support
@@ -15,8 +13,8 @@ import imas
 def get_training_db_entry(convert=False) -> imas.DBEntry:
     """Open and return an ``imas.DBEntry`` pointing to the training data.
 
-        Args:
-            convert: if True, converts assets to default DD version 
+    Args:
+        convert: if True, converts assets to default DD version
     """
     assets_path = files(imas) / "assets/"
     entry = imas.DBEntry(f"imas:ascii?path={assets_path}", "r")

--- a/imas/training.py
+++ b/imas/training.py
@@ -12,15 +12,22 @@ except ImportError:  # Python 3.8 support
 import imas
 
 
-def get_training_db_entry() -> imas.DBEntry:
-    """Open and return an ``imas.DBEntry`` pointing to the training data."""
+def get_training_db_entry(convert=False) -> imas.DBEntry:
+    """Open and return an ``imas.DBEntry`` pointing to the training data.
+
+        Args:
+            convert: if True, converts assets to default DD version 
+    """
     assets_path = files(imas) / "assets/"
     entry = imas.DBEntry(f"imas:ascii?path={assets_path}", "r")
 
-    output_entry = imas.DBEntry("imas:memory?path=/", "w")
+    version = imas.dd_zip.latest_dd_version() if convert else "3.39.0"
+    output_entry = imas.DBEntry("imas:memory?path=/", "w", dd_version=version)
     for ids_name in ["core_profiles", "equilibrium"]:
         ids = entry.get(ids_name, autoconvert=False)
-        with patch.dict("os.environ", {"IMAS_AL_DISABLE_VALIDATE": "1"}):
+        if convert:
             output_entry.put(imas.convert_ids(ids, output_entry.dd_version))
+        else:
+            output_entry.put(ids)
     entry.close()
     return output_entry

--- a/imas/training.py
+++ b/imas/training.py
@@ -19,7 +19,7 @@ def get_training_db_entry(convert=False) -> imas.DBEntry:
     assets_path = files(imas) / "assets/"
     entry = imas.DBEntry(f"imas:ascii?path={assets_path}", "r")
 
-    version = imas.dd_zip.latest_dd_version() if convert else "3.39.0"
+    version = None if convert else "3.39.0"
     output_entry = imas.DBEntry("imas:memory?path=/", "w", dd_version=version)
     for ids_name in ["core_profiles", "equilibrium"]:
         ids = entry.get(ids_name, autoconvert=False)


### PR DESCRIPTION
The equilibrium had one inconsistent coordinate size (empty but allocated grids_ggd), this is now fixed.
By consequence I've removed the disabling of coord checks in the training data load function, and took this opportunity to allow loading the data in its original version (avoids missing quantities due to DD4 conversion otherwise).