### PR TITLE
list all ids names used across all data dictionary versions

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,6 +21,7 @@ IMAS-Python public API
    ids_convert.convert_ids
    ids_data_type.IDSDataType
    ids_factory.IDSFactory
+   ids_factory.get_all_ids_names
    ids_identifiers.identifiers
    ids_metadata.IDSMetadata
    ids_metadata.IDSType

--- a/imas/__init__.py
+++ b/imas/__init__.py
@@ -23,7 +23,7 @@ from .convert_core_edge_plasma import (
 from .db_entry import DBEntry
 from .ids_convert import convert_ids
 from .ids_data_type import IDSDataType
-from .ids_factory import IDSFactory
+from .ids_factory import IDSFactory, get_all_ids_names
 from .ids_identifiers import identifiers
 from .ids_metadata import IDSMetadata, IDSType
 from .ids_primitive import IDSPrimitive
@@ -42,6 +42,7 @@ __all__ = [
     "DBEntry",
     "IDSDataType",
     "IDSFactory",
+    "get_all_ids_names",
     "IDSMetadata",
     "IDSPrimitive",
     "IDSStructure",

--- a/imas/ids_factory.py
+++ b/imas/ids_factory.py
@@ -17,6 +17,16 @@ from imas.ids_toplevel import IDSToplevel
 logger = logging.getLogger(__name__)
 
 
+def get_all_ids_names() -> list[str]:
+    """Get all IDS names available across all dd versions"""
+    ids_names: set[str] = set()
+
+    for dd_version in dd_zip.dd_xml_versions():
+        ids_names.update(IDSFactory(dd_version).ids_names())
+
+    return sorted(ids_names)
+
+
 class IDSFactory:
     """Factory class generating IDSToplevel elements for specific DD versions.
 

--- a/imas/test/test_ids_factory.py
+++ b/imas/test/test_ids_factory.py
@@ -1,7 +1,7 @@
 import pytest
 
-from imas.dd_zip import latest_dd_version
-from imas.ids_factory import IDSFactory
+from imas.dd_zip import dd_xml_versions, latest_dd_version
+from imas.ids_factory import IDSFactory, get_all_ids_names
 
 
 def test_ids_factory_with_version():
@@ -33,3 +33,10 @@ def test_ids_factory_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("IMAS_VERSION", version)
     factory = IDSFactory()
     assert factory._version == version
+
+
+def test_get_all_ids_names():
+    ids_names = get_all_ids_names()
+
+    for dd_version in dd_xml_versions():
+        assert set(IDSFactory(dd_version).ids_names()) <= set(ids_names)


### PR DESCRIPTION
Use case --
Showing all ids names irrespective data dictionary versions where we have moved/deleted/new IDS names. 
Sometimes it may be choice of the user of which data dictionary version he wanted to use.
