### PR TITLE
Improve speed of `hasattr` on IDS structures

### DIFF
--- a/imas/ids_structure.py
+++ b/imas/ids_structure.py
@@ -57,7 +57,7 @@ class IDSStructure(IDSBase):
     def __getattr__(self, name):
         if name not in self._children:
             raise AttributeError(
-                f"IDS structure '{self._path}' has no attribute '{name}'"
+                f"IDS structure '{self.metadata.path_string}' has no attribute '{name}'"
             )
         # Create child node
         child_meta = self._children[name]


### PR DESCRIPTION
Replace `_path` (which constructs the path including AoS indices) with the static `metadata.path_string` when an attribute cannot be found.

Speeds up the following sample from 110ms to 0.5ms (200x gain):

```python
import timeit
import imas

cp = imas.IDSFactory().core_profiles()
cp.profiles_1d.resize(1000)
def totime():
    hasattr(cp.profiles_1d[999], "xyz")
print(timeit.repeat(totime, number=1000))
```

**Changed behaviour:**
Before: `AttributeError: IDS structure 'profiles_1d[999]' has no attribute 'xyz'` After: `AttributeError: IDS structure 'profiles_1d' has no attribute 'xyz'`

Since the index of an AoS is not relevant for whether an attribute exists or not, I believe this is not a problem.